### PR TITLE
Enable boxed math linter

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -51,7 +51,7 @@
                                    ;; because :implicit-dependencies can only work for a certain corner case starting from 1.10.
                                    :exclude-linters [:implicit-dependencies]
                                    :exclude-namespaces [refactor-nrepl.plugin]
-                                   :add-linters [:performance]
+                                   :add-linters [:boxed-math :performance]
                                    :config-files ["eastwood.clj"]}}
              :clj-kondo [:test
                          {:dependencies [[clj-kondo "2022.10.14"]]}]

--- a/test/haystack/analyzer_test.clj
+++ b/test/haystack/analyzer_test.clj
@@ -35,8 +35,9 @@
 ;; ## Test fixtures
 
 (def form1 '(throw (ex-info "oops" {:x 1} (ex-info "cause" {:y 2}))))
-(def form2 '(do (defn oops [] (+ 1 "2"))
-                (oops)))
+(def form2 '(let [^long num "2"] ;; Type hint to make eastwood happy
+              (defn oops [] (+ 1 num))
+              (oops)))
 (def form3 '(not-defined))
 (def form4 '(divi 1 0))
 
@@ -152,9 +153,9 @@
             dup? #(or (= (:name %1) (:name %2))
                       (and (= (:file %1) (:file %2))
                            (= (:line %1) (:line %2))))]
-        (is (every? (fn [[i v]] (dup? v (get ixd1 (dec i))))
+        (is (every? (fn [[i v]] (dup? v (get ixd1 (dec ^long i))))
                     (filter (comp :dup :flags val) ixd1)))
-        (is (every? (fn [[i v]] (dup? v (get ixd2 (dec i))))
+        (is (every? (fn [[i v]] (dup? v (get ixd2 (dec ^long i))))
                     (filter (comp :dup :flags val) ixd2)))))))
 
 (deftest exception-causes-test


### PR DESCRIPTION
This PR adds some type hints to enable the boxed math eastwood linter again