### PR TITLE
Categorize more frames as `:tooling`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ defaults: &defaults
 executors:
   openjdk8:
     docker:
-      - image: circleci/clojure:openjdk-8-lein-2.9.5
+      - image: circleci/clojure:openjdk-8-lein-2.9.1-node
     environment:
       LEIN_ROOT: "true"   # we intended to run lein as root
       JVM_OPTS: -Xmx3200m # limit the maximum heap size to prevent out of memory errors
@@ -32,7 +32,7 @@ executors:
 
   openjdk11:
     docker:
-      - image: circleci/clojure:openjdk-11-lein-2.9.5
+      - image: circleci/clojure:openjdk-11-lein-2.9.3-buster-node
     environment:
       LEIN_ROOT: "true"   # we intended to run lein as root
       JVM_OPTS: -Xmx3200m --illegal-access=deny # forbid reflective access (this flag doesn't exist for JDK8 or JDK17+)
@@ -40,7 +40,7 @@ executors:
 
   openjdk17:
     docker:
-      - image: circleci/clojure:openjdk-17-lein-2.9.5-buster
+      - image: circleci/clojure:openjdk-17-lein-2.9.5-buster-node
     environment:
       LEIN_ROOT: "true"   # we intended to run lein as root
       JVM_OPTS: -Xmx3200m
@@ -153,8 +153,11 @@ jobs:
           cache_version: << parameters.clojure_version >>|<< parameters.jdk_version >>
           steps:
             - run:
-                name: Running tests
+                name: Running JVM tests
                 command: make test
+            - run:
+                name: Running cljs tests
+                command: make test-cljs
 
 ######################################################################
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 ## Changes
 
 * `analyzer`: include a `:phase` key for the causes that include a `:clojure.error/phase`.
+* Categorize more frames as `:tooling`
+  * `:tooling` now intends to more broadly hide things that are commonly Clojure-internal / irrelevant to the application programmer.
+  * New exhaustive list:
+    * `cider.*`
+    * `clojure.core/apply`
+    * `clojure.core/binding-conveyor-fn`
+    * `clojure.core/eval`
+    * `clojure.core/with-bindings`
+    * `clojure.lang.Compiler`
+    * `clojure.lang.RT`
+    * `clojure.main/repl`
+    * `nrepl.*`
+    * `java.lang.Thread/run` (if it's the root element of the stacktrace)
 
 ## 0.1.0
 

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ clean:
 test: clean
 	lein with-profile -user,-dev,+$(VERSION) test
 
-test-cljs:
-	lein cljsbuild once
+test-cljs: clean
+	lein with-profile -user,-dev,+cljsbuild cljsbuild once
 	node target/cljs/test.js
 
 cljfmt:

--- a/README.org
+++ b/README.org
@@ -186,14 +186,6 @@ We get back a sequence of maps, one for each cause, which contain
 additional information about each frame discovered from the class path.
 
 ** Development
-*** Deployment
-
-Here's how to deploy to Clojars:
-
-#+begin_src sh
-git tag -a v0.1.0 -m "0.1.0"
-git push --tags
-#+end_src
 
 *** Creating a parser
 
@@ -254,6 +246,15 @@ for writing Instaparse grammars:
 
 - If your parser fails on an input, [[https://github.com/Engelberg/instaparse#revealing-hidden-information][reveal hidden information]] to get a
   better understanding of what happened.
+
+*** Deployment
+
+Here's how to deploy to Clojars:
+
+#+begin_src sh
+git tag -a v0.1.0 -m "0.1.0"
+git push --tags
+#+end_src
 
 ** Changelog
 

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 ;; whenever we perform a deployment.
 (defproject mx.cider/haystack (or (not-empty (System/getenv "PROJECT_VERSION"))
                                   "0.0.0")
-  :description ""
+  :description "Let's make the most of Clojure's infamous stacktraces!"
   :url "https://github.com/clojure-emacs/haystack"
   :license {:name "Eclipse Public License"
             :url "https://www.eclipse.org/legal/epl-v10.html"}
@@ -16,15 +16,7 @@
                                     :username :env/clojars_username
                                     :password :env/clojars_password
                                     :sign-releases false}]]
-  :plugins [[lein-cljsbuild "1.1.8"]]
-  :cljsbuild {:builds
-              [{:id "test"
-                :compiler
-                {:main haystack.test.runner
-                 :output-dir "target/cljs/test"
-                 :output-to "target/cljs/test.js"
-                 :target :nodejs}
-                :source-paths ["src" "test"]}]}
+
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.11.1"]
                                        [org.clojure/clojurescript "1.11.4"]]}
 
@@ -40,7 +32,16 @@
                                       "https://oss.sonatype.org/content/repositories/snapshots"]]
                       :dependencies [[org.clojure/clojure "1.12.0-master-SNAPSHOT"]
                                      [org.clojure/clojure "1.12.0-master-SNAPSHOT" :classifier "sources"]]}
-
+             :cljsbuild {:plugins   [[lein-cljsbuild "1.1.8"]]
+                         :dependencies [[lein-doo "0.1.11"]]
+                         :cljsbuild {:builds
+                                     [{:id "test"
+                                       :compiler
+                                       {:main haystack.test.runner
+                                        :output-dir "target/cljs/test"
+                                        :output-to "target/cljs/test.js"
+                                        :target :nodejs}
+                                       :source-paths ["src" "test"]}]}}
              :cljfmt [:test
                       {:plugins [[lein-cljfmt "0.9.0" :exclusions [org.clojure/clojure
                                                                    org.clojure/clojurescript]]]}]

--- a/src/haystack/analyzer.clj
+++ b/src/haystack/analyzer.clj
@@ -120,10 +120,12 @@
     (flag-frame frame :repl)
     frame))
 
-(defn- tool? [frame-name last?]
+(def ^:private tooling-frame-re
+  #"^clojure\.lang\.AFn|^clojure\.lang\.RestFn|^clojure\.lang\.RT|clojure\.lang\.Compiler|^nrepl\.|^cider\.|^clojure\.core/eval|^clojure\.core/apply|^clojure\.core/with-bindings|^clojure\.core/binding-conveyor-fn|^clojure\.main/repl")
+
+(defn- tooling-frame-name? [frame-name last?]
   (let [demunged (repl/demunge frame-name)]
-    (boolean (or (re-find #"^clojure\.lang\.AFn|^clojure\.lang\.RestFn|^clojure\.lang\.RT|clojure\.lang\.Compiler|^nrepl\.|^cider\.|^clojure\.core/eval|^clojure\.core/apply|^clojure\.core/with-bindings|^clojure\.core/binding-conveyor-fn|^clojure\.main/repl"
-                          demunged)
+    (boolean (or (re-find tooling-frame-re demunged)
                  (and last?
                       ;; Everything runs from a Thread, so this frame, if at root, is irrelevant.
                       ;; However one can invoke this method 'by hand', which is why we also observe `last?`.
@@ -138,7 +140,7 @@
     (into []
           (map-indexed (fn [i {frame-name :name :as frame}]
                          (cond-> frame
-                           (some-> frame-name (tool? (= i last-index)))
+                           (some-> frame-name (tooling-frame-name? (= i last-index)))
                            (flag-frame :tooling))))
           frames)))
 

--- a/src/haystack/analyzer.clj
+++ b/src/haystack/analyzer.clj
@@ -132,9 +132,10 @@
                       (re-find #"^java\.lang\.Thread/run" demunged))))))
 
 (defn- flag-tooling
-  "Walk the call stack from top to bottom, flagging frames below the first call
-  to `clojure.lang.Compiler` or `nrepl.*` as `:tooling` to
-  distinguish compilation and nREPL middleware frames from user code."
+  "Given a collection of stack `frames`, marks the 'tooling' ones as such.
+
+  A 'tooling' frame is one that generally represents Clojure, JVM, nREPL or CIDER internals,
+  and that is therefore not relevant to application-level code."
   [frames]
   (let [last-index (dec (count frames))]
     (into []

--- a/src/haystack/analyzer.clj
+++ b/src/haystack/analyzer.clj
@@ -54,7 +54,7 @@
   (or (info/file-path path) (second (resource/resource-path-tuple path))))
 
 (defn- frame->url
-  "Return a java.net.URL to the file referenced in the frame, if possible.
+  "Return a `java.net.URL` to the file referenced in the frame, if possible.
   Useful for handling clojure vars which may not exist. Uncomprehensive list of
   reasons for this:
   * Failed refresh
@@ -336,7 +336,7 @@
           (flag-tooling)))))
 
 (defn- analyze-cause
-  "Analyze the `cause-data` of an exception in `Throwable->map` format."
+  "Analyze the `cause-data` of an exception, in `Throwable->map` format."
   [cause-data print-fn]
   (let [pprint-str #(let [writer (StringWriter.)]
                       (print-fn % writer)
@@ -378,8 +378,8 @@
   "Return the analyzed cause chain for `exception` beginning with the
   thrown exception. `exception` can be an instance of `Throwable` or a
   map in the same format as `Throwable->map`. For `ex-info`
-  exceptions, the response contains a :data slot with the pretty
-  printed data. For clojure.spec asserts, the :spec slot contains a
+  exceptions, the response contains a `:data` slot with the pretty
+  printed data. For clojure.spec asserts, the `:spec` slot contains a
   map of pretty printed components describing spec failures."
   {:added "0.1.0"}
   ([exception]

--- a/src/haystack/analyzer.clj
+++ b/src/haystack/analyzer.clj
@@ -121,12 +121,13 @@
     frame))
 
 (defn- tool? [frame-name last?]
-  (boolean (or (re-find #"^clojure\.lang\.AFn|^clojure\.lang\.RestFn|^clojure\.lang\.RT|clojure\.lang\.Compiler|^nrepl\.|^cider\.|^clojure\.core/eval|^clojure\.core/apply|^clojure\.core/with-bindings|^clojure\.core/binding-conveyor-fn|^clojure\.main/repl"
-                        frame-name)
-               (and last?
-                    ;; Everything runs from a Thread, so this frame, if at root, is irrelevant.
-                    ;; However one can invoke this method 'by hand', which is why we also observe `last?`.
-                    (re-find #"^java\.lang\.Thread/run" frame-name)))))
+  (let [demunged (repl/demunge frame-name)]
+    (boolean (or (re-find #"^clojure\.lang\.AFn|^clojure\.lang\.RestFn|^clojure\.lang\.RT|clojure\.lang\.Compiler|^nrepl\.|^cider\.|^clojure\.core/eval|^clojure\.core/apply|^clojure\.core/with-bindings|^clojure\.core/binding-conveyor-fn|^clojure\.main/repl"
+                          demunged)
+                 (and last?
+                      ;; Everything runs from a Thread, so this frame, if at root, is irrelevant.
+                      ;; However one can invoke this method 'by hand', which is why we also observe `last?`.
+                      (re-find #"^java\.lang\.Thread/run" demunged))))))
 
 (defn- flag-tooling
   "Walk the call stack from top to bottom, flagging frames below the first call

--- a/test/haystack/analyzer_test.clj
+++ b/test/haystack/analyzer_test.clj
@@ -610,23 +610,25 @@
                                (is (= expected
                                       (#'sut/tool? frame-name false)))
                                true)
-    "cider.foo"                           true
-    "acider.foo"                          false
+    "cider.foo"                                                 true
+    "acider.foo"                                                false
     ;; `+` is "application" level, should not be hidden:
-    "clojure.core/+"                      false
+    "clojure.core/+"                                            false
     ;; `apply` typically is internal, should be hidden:
-    "clojure.core/apply"                  true
-    "clojure.core/binding-conveyor-fn/fn" true
-    "clojure.core/eval"                   true
-    "clojure.core/with-bindings*"         true
-    "clojure.lang.AFn/applyTo"            true
-    "clojure.lang.AFn/applyToHelper"      true
-    "clojure.lang.RestFn/invoke"          true
-    "clojure.main/repl"                   true
-    "nrepl.foo"                           true
-    "anrepl.foo"                          false
+    "clojure.core/apply"                                        true
+    "clojure.core/binding-conveyor-fn/fn"                       true
+    "clojure.core/eval"                                         true
+    "clojure.core/with-bindings*"                               true
+    "clojure.lang.AFn/applyTo"                                  true
+    "clojure.lang.AFn/applyToHelper"                            true
+    "clojure.lang.RestFn/invoke"                                true
+    "clojure.main/repl"                                         true
+    "clojure.main$repl$read_eval_print__9234$fn__9235/invoke"   true
+    "nrepl.foo"                                                 true
+    "nrepl.middleware.interruptible_eval$evaluate/invokeStatic" true
+    "anrepl.foo"                                                false
     ;; important case - `Numbers` is relevant, should not be hidden:
-    "clojure.lang.Numbers/divide"         false)
+    "clojure.lang.Numbers/divide"                               false)
 
   (is (not (#'sut/tool? "java.lang.Thread/run" false)))
   (is (#'sut/tool? "java.lang.Thread/run" true)))

--- a/test/haystack/analyzer_test.clj
+++ b/test/haystack/analyzer_test.clj
@@ -605,10 +605,10 @@
                         (sut/analyze e)))
                     (map :phase))))))))
 
-(deftest tool?
+(deftest tooling-frame-name?
   (are [frame-name expected] (testing frame-name
                                (is (= expected
-                                      (#'sut/tool? frame-name false)))
+                                      (#'sut/tooling-frame-name? frame-name false)))
                                true)
     "cider.foo"                                                 true
     "acider.foo"                                                false
@@ -630,8 +630,8 @@
     ;; important case - `Numbers` is relevant, should not be hidden:
     "clojure.lang.Numbers/divide"                               false)
 
-  (is (not (#'sut/tool? "java.lang.Thread/run" false)))
-  (is (#'sut/tool? "java.lang.Thread/run" true)))
+  (is (not (#'sut/tooling-frame-name? "java.lang.Thread/run" false)))
+  (is (#'sut/tooling-frame-name? "java.lang.Thread/run" true)))
 
 (deftest flag-tooling
   (is (= [{:name "cider.foo", :flags #{:tooling}}

--- a/test/haystack/parser/clojure/repl_test.cljc
+++ b/test/haystack/parser/clojure/repl_test.cljc
@@ -113,7 +113,7 @@
               :reason
               #?(:clj [{:tag :regexp :expecting "[a-zA-Z0-9_$/-]"}
                        {:tag :regexp :expecting "[^\\S\\r\\n]+"}]
-                 :cljs [{:tag :regexp, :expecting "/^[a-zA-Z0-9_$\\/-]/"}
+                 :cljs [{:tag :regexp, :expecting "/^[a-zA-Z0-9_$/-]/"}
                         {:tag :regexp, :expecting "/^[^\\S\\r\\n]+/"}])
               :line 1
               :column 1

--- a/test/haystack/parser/clojure/stacktrace_test.cljc
+++ b/test/haystack/parser/clojure/stacktrace_test.cljc
@@ -115,7 +115,7 @@
               :reason
               #?(:clj [{:tag :regexp :expecting "[a-zA-Z0-9_$/-]"}
                        {:tag :regexp :expecting "[^\\S\\r\\n]+"}]
-                 :cljs [{:tag :regexp, :expecting "/^[a-zA-Z0-9_$\\/-]/"}
+                 :cljs [{:tag :regexp, :expecting "/^[a-zA-Z0-9_$/-]/"}
                         {:tag :regexp, :expecting "/^[^\\S\\r\\n]+/"}])
               :line 1
               :column 1

--- a/test/haystack/parser/java_test.cljc
+++ b/test/haystack/parser/java_test.cljc
@@ -115,7 +115,7 @@
               :reason
               #?(:clj [{:tag :regexp, :expecting "[a-zA-Z0-9_$/-]"}
                        {:tag :regexp, :expecting "[^\\S\\r\\n]+"}]
-                 :cljs [{:tag :regexp, :expecting "/^[a-zA-Z0-9_$\\/-]/"}
+                 :cljs [{:tag :regexp, :expecting "/^[a-zA-Z0-9_$/-]/"}
                         {:tag :regexp, :expecting "/^[^\\S\\r\\n]+/"}])
               :line 1
               :column 1


### PR DESCRIPTION
* `:tooling` now intends to more broadly hide things that are commonly Clojure-internal / irrelevant to the application programmer.
  * New exhaustive list:
    * `cider.*`
    * `clojure.core/apply`
    * `clojure.core/binding-conveyor-fn`
    * `clojure.core/eval`
    * `clojure.core/with-bindings`
    * `clojure.lang.Compiler`
    * `clojure.lang.RT`
    * `clojure.main/repl`
    * `nrepl.*`
    * `java.lang.Thread/run` (if it's the root element of the stacktrace)

With this, `tooling` will be able to more effectively hide internals in the following UI:

<img width="706" alt="image" src="https://github.com/clojure-emacs/haystack/assets/1162994/df7104a1-d67a-485d-97be-27517bbcc244">

...none of the other filters are as adequate.

Care has been taken to not hide stuff that can be considered relevant. For instance, for `(/ 2 0)`, `clojure.lang.Numbers.java` is the code that ultimately runs that code, so it's good to show.

Which is to say, clojure.lang classes cannot be hidden altogether. `clojure.lang.Compiler` and `clojure.lang.RT` yes. And also a few select clojure.core functions, related to eval, fn invocation, and lazy sequence internals.

Predictably, our criterion will be refined over time, but this seems a good fresh start for now.

Cheers - V