### PR TITLE
`analyzer`: include a `:phase` key for the causes that include it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+## Changes
+
+* `analyzer`: include a `:phase` key for the causes that include a `:clojure.error/phase`.
+
 ## 0.1.0
 
 ### Bugs fixed

--- a/src/haystack/analyzer.clj
+++ b/src/haystack/analyzer.clj
@@ -332,6 +332,7 @@
                       (print-fn % writer)
                       (str writer))
         m {:class (name (:type cause-data))
+           :phase (-> cause-data :data :clojure.error/phase)
            :message (:message cause-data)
            :stacktrace (analyze-stacktrace-data
                         (cond (seq (:trace cause-data))

--- a/test/haystack/analyzer_test.clj
+++ b/test/haystack/analyzer_test.clj
@@ -592,4 +592,15 @@
                     :method "applyToHelper"
                     :type :java
                     :flags #{:java}}
-                   (dissoc (nth stacktrace 0) :file-url)))))))))
+                   (dissoc (nth stacktrace 0) :file-url))))))))
+
+  (let [{:keys [major minor]} *clojure-version*]
+    (when-not (and (= 1 major)
+                   (< (long minor) 10))
+      (testing "Includes a `:phase` for the causes that include it"
+        (is (= [:macro-syntax-check nil]
+               (->> (try
+                      (eval '(let [1]))
+                      (catch Throwable e
+                        (sut/analyze e)))
+                    (map :phase))))))))


### PR DESCRIPTION
> Related https://github.com/clojure-emacs/cider/discussions/3338
> Related https://github.com/clojure-emacs/cider/issues/3418

Introduces a `:phase` k-v that cider-nrepl will relay.

Note that currently we already express this data:

```lisp
(-->
  id                                 "183"
  op                                 "analyze-last-stacktrace"
  session                            "75d291f3-6362-4f19-9f98-5a1d9b5d3ef8"
  time-stamp                         "2023-08-19 20:33:36.513573000"
  nrepl.middleware.print/buffer-size 4096
  nrepl.middleware.print/options     (dict ...)
  nrepl.middleware.print/print       "cider.nrepl.pprint/pprint"
  nrepl.middleware.print/quota       1048576
  nrepl.middleware.print/stream?     "1"
)
(<--
  id         "183"
  session    "75d291f3-6362-4f19-9f98-5a1d9b5d3ef8"
  time-stamp "2023-08-19 20:33:37.291545000"
  class      "clojure.lang.Compiler$CompilerException"
  column     25
  data       "#:clojure.error{:phase :compile-syntax-check,
                :line 27,
                :column 25,
                :source
                \"*cider-repl ~/haystack:localhost:41235(clj)*\",
                :symbol sut/tool?}"
  file       "*cider-repl ~/haystack:localhost:41235(clj)*"
```

...however it's edn-encoded. Running [parseedn](https://github.com/clojure-emacs/parseedn) on every cause seems a bit risky/expensive.

I also wanted to make sure that this key is present no matter what. There's existing conditional logic for including `:clojure.error/phase`, that's fine for other use cases, but getting it "no matter what" is simpler to reason about.

Cheers - V