### PR TITLE
`analyzer`: introduce a `:compile-like` key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+* `analyzer`: include a `:compile-like` key which indicates if the error happened at a "compile-like" phase.
+  * It represents exceptions that happen at runtime (and therefore never include a `:phase`) which however, represent code that cannot possibly work, and therefore are a "compile-like" exception (i.e. a linter could have caught them).
+  * The set of conditions which are considered a 'compile-like' exception is private and subject to change. 
+
 ## 0.2.0 (2023-08-20)
 
 ## Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * `analyzer`: include a `:compile-like` key which indicates if the error happened at a "compile-like" phase.
   * It represents exceptions that happen at runtime (and therefore never include a `:phase`) which however, represent code that cannot possibly work, and therefore are a "compile-like" exception (i.e. a linter could have caught them).
   * The set of conditions which are considered a 'compile-like' exception is private and subject to change. 
+* Use Orchard [0.15.1](https://github.com/clojure-emacs/orchard/blob/v0.15.1/CHANGELOG.md#0151-2023-09-21).
 
 ## 0.2.0 (2023-08-20)
 

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :url "https://github.com/clojure-emacs/haystack"
   :license {:name "Eclipse Public License"
             :url "https://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[cider/orchard "0.11.0"]
+  :dependencies [[cider/orchard "0.15.1"]
                  [instaparse "1.4.12" :exclusions [org.clojure/clojure]]]
   :pedantic? ~(if (System/getenv "CI")
                 :abort


### PR DESCRIPTION
## Context

In CIDER, when I type `(.foo "")` at the repl, no stacktrace should be displayed, because it adds nothing to the message that already will be displayed.

However, this is a runtime exception, not a compile-one, so we can't use our new `:phase` logic.

I asked about that here: https://ask.clojure.org/index.php/13339/tools-better-detect-errors-coming-existing-methods-fields

## Changes

Introduce a `:compile-like` key indicating if we deem the exception "compile-like".

We can expand the meaning of it as we find more, similar cases.

Cheers - V